### PR TITLE
Align multiline method chains with rubocop and style discussions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ By the way, if you're into Rails you might want to check out the complementary
     When continuing a chained method invocation on another line,
     include the `.` on the first line to indicate that the
     expression continues.
+  <sup>[[link](#consistent-multi-line-chains)]</sup>
 
     ```Ruby
     # bad - need to read ahead to the second line to know that the chain continues

--- a/README.md
+++ b/README.md
@@ -429,39 +429,25 @@ By the way, if you're into Rails you might want to check out the complementary
   ```
 
 * <a name="consistent-multi-line-chains"></a>
-    Adopt a consistent multi-line method chaining style. There are two
-    popular styles in the Ruby community, both of which are considered
-    good - leading `.` (Option A) and trailing `.` (Option B).
-<sup>[[link](#consistent-multi-line-chains)]</sup>
-
-  * **(Option A)** When continuing a chained method invocation on
-    another line keep the `.` on the second line.
-
-    ```Ruby
-    # bad - need to consult first line to understand second line
-    one.two.three.
-      four
-
-    # good - it's immediately clear what's going on the second line
-    one.two.three
-      .four
-    ```
-
-  * **(Option B)** When continuing a chained method invocation on another line,
+    When continuing a chained method invocation on another line,
     include the `.` on the first line to indicate that the
     expression continues.
 
     ```Ruby
     # bad - need to read ahead to the second line to know that the chain continues
-    one.two.three
-      .four
+    one
+    .two
+    .three
+    .four
 
     # good - it's immediately clear that the expression continues beyond the first line
-    one.two.three.
-      four
+    one.
+    two.
+    three.
+    four
     ```
 
-  A discussion on the merits of both alternative styles can be found
+  A discussion on the merits of alternative styles can be found
   [here](https://github.com/bbatsov/ruby-style-guide/pull/176).
 
 * <a name="no-double-indent"></a>


### PR DESCRIPTION
The style guide was behind style discussions and the `.rubocop.yml` for multiline method chains.

Now it is not.  The guideline is now this:

```
# bad - need to read ahead to the second line to know that the chain continues
one
.two
.three
.four

# good - it's immediately clear that the expression continues beyond the first line
one.
two.
three.
four
```

(The indentation on that guideline is aligned with the current recommendation in the `.rubocop.yml`.)
