### PR TITLE
Lint Section: A through D

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,5 @@
 # See all descriptions at this link
 # https://www.rubydoc.info/gems/rubocop/RuboCop
-AllCops:
-  TargetRubyVersion: 2.3
-
-require: ./lib/rubocop/custom_cops
-
-# These are all the cops that are enabled in the default configuration.
 
 # Indent private/protected/public as deep as method definitions
 Layout/AccessModifierIndentation:
@@ -763,21 +757,20 @@ Metrics/PerceivedComplexity:
 ### Warnings
 
 Lint/AmbiguousOperator:
-  Description: >-
-                 Checks for ambiguous operators in the first argument of a
-                 method invocation without parentheses.
   Enabled: false
 
+# TODO: 2018/08/20 Discuss at next style guide meeting
+# Pretty sure we want to enable?
 Lint/AmbiguousRegexpLiteral:
-  Description: >-
-                 Checks for ambiguous regexp literals in the first argument of
-                 a method invocation without parenthesis.
   Enabled: false
 
+# TODO: 2018/08/20 Discuss at next style guide meeting
+# VERY sure we want to enable this rule
 Lint/AssignmentInCondition:
-  Description: "Don't use assignment in conditions."
   Enabled: false
   AllowSafeAssignment: true
+
+################ Things below this are not reviewed/corrected ########
 
 Layout/BlockAlignment:
   Description: 'Align block ends correctly.'
@@ -787,10 +780,6 @@ Layout/ConditionPosition:
   Description: 'Checks for condition placed in a confusing position relative to the keyword.'
   Enabled: false
 
-Lint/Debugger:
-  Description: 'Check for debugger calls.'
-  Enabled: true
-
 Layout/DefEndAlignment:
   Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
@@ -799,10 +788,6 @@ Layout/DefEndAlignment:
   # calls like `private`, `public`, etc, if present in front of the `def`
   # keyword on the same line.
   EnforcedStyleAlignWith: start_of_line
-
-Lint/DeprecatedClassMethods:
-  Description: 'Check for deprecated class method calls.'
-  Enabled: true
 
 Lint/ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -759,17 +759,6 @@ Metrics/PerceivedComplexity:
 Lint/AmbiguousOperator:
   Enabled: false
 
-# TODO: 2018/08/20 Discuss at next style guide meeting
-# Pretty sure we want to enable?
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
-# TODO: 2018/08/20 Discuss at next style guide meeting
-# VERY sure we want to enable this rule
-Lint/AssignmentInCondition:
-  Enabled: false
-  AllowSafeAssignment: true
-
 ################ Things below this are not reviewed/corrected ########
 
 Layout/BlockAlignment:


### PR DESCRIPTION
Changes to the Lint section, affecting the following cops:

- Lint/AmbiguousBlockAssociation
- Lint/AmbiguousOperator
- Lint/AmbiguousRegexpLiteral
- Lint/AssignmentInCondition
- Lint/BigDecimalNew
- Lint/BooleanSymbol
- Lint/CircularArgumentReference
- Lint/Debugger
- Lint/DeprecatedClassMethods
- Lint/DuplicateCaseCondition
- Lint/DuplicateMethods
- Lint/DuplicatedKey

Strategy was iterate through the list, checking for entries throughout the file. If entry was found, move it to roughly right place. If not, should it be enabled? If unclear, tag for discussion.

As an added bonus, I put all bad examples into a scratch file in this folder, and checked to see if rubocop captured them accurately. I also ran all of these against Jobber, and the only ones that passed were `Lint/CircularArgumentReference`, `Lint/Lint/DuplicateCaseCondition` and `Lint/Lint/DuplicatedKey` 😢 

For these, the ones worth documenting are not currently enabled IMO, but documentation should be added if they are enabled after discussion.

PTAL
@JeffMarvin @C-Flatla 
NoteI'm waiting on #12 to be merged first.