### PR TITLE
Changes to Lint section, E through to L

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -804,30 +804,14 @@ Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: true
 
-Lint/ElseLayout:
-  Description: 'Check for odd code arrangement in an else block.'
-  Enabled: false
 
-Lint/EmptyEnsure:
-  Description: 'Checks for empty ensure block.'
-  Enabled: true
 
-Lint/EmptyInterpolation:
-  Description: 'Checks for empty string interpolation.'
-  Enabled: true
+################ Things below this are not reviewed/corrected ########
 
 Layout/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: true
   EnforcedStyleAlignWith: keyword
-
-Lint/EndInMethod:
-  Description: 'END blocks should not be placed inside method definitions.'
-  Enabled: true
-
-Lint/EnsureReturn:
-  Description: 'Never use return in an ensure block.'
-  Enabled: true
 
 Lint/HandleExceptions:
   Description: "Don't suppress exception."

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -813,20 +813,6 @@ Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: keyword
 
-Lint/LiteralAsCondition:
-  Description: 'Checks of literals used in conditions.'
-  Enabled: false
-
-Lint/LiteralInInterpolation:
-  Description: 'Checks for literals used in interpolation.'
-  Enabled: false
-
-Lint/Loop:
-  Description: >-
-                 Use Kernel#loop with break rather than begin/end/until or
-                 begin/end/while for post-loop tests.
-  Enabled: true
-
 Lint/ParenthesesAsGroupedExpression:
   Description: >-
                  Checks for method calls with a space before the opening

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -813,10 +813,6 @@ Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: keyword
 
-Lint/HandleExceptions:
-  Description: "Don't suppress exception."
-  Enabled: true
-
 Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -770,6 +770,27 @@ By the way, if you're into Rails you might want to check out the complementary
   end
   ```
 
+* <a name="else-layout"></a>
+  Avoid having part of an expression on the same line as the else keyword.
+<sup>[[link](#else-layout)]</sup>
+
+  ```Ruby
+  # bad
+  if something
+    # ...
+  else do_this
+    do_that
+  end
+
+  # good
+  if something
+    # ...
+  else
+    do_this
+    do_that
+  end
+  ```
+
 * <a name="ternary-operator"></a>
   Favor the ternary operator(`?:`) over `if/then/else/end` constructs.
   It's more common and obviously more concise.


### PR DESCRIPTION
Changes to the Lint section, affecting the following cops:

Lint/EachWithObjectArgument
Lint/ElseLayout
Lint/EmptyEnsure
Lint/EmptyExpression
Lint/EmptyInterpolation
Lint/EmptyWhen
Lint/EndInMethod
Lint/EnsureReturn
Lint/ErbNewArguments
Lint/FloatOutOfRange
Lint/FormatParameterMismatch
Lint/HandleExceptions
Lint/ImplicitStringConcatenation
Lint/IneffectiveAccessModifier
Lint/InheritException
Lint/InterpolationCheck
Lint/LiteralAsCondition
Lint/LiteralInInterpolation
Lint/Loop

Mostly this is removing defaults of things we had enabled, and don't need to. There's also some of enabling cops that I'm not sure why we disabled them.

@C-Flatla @JeffMarvin Making more review work for you guys, I've made it halfway through my section! :P