### PR TITLE
Lint Section: M through R

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -849,16 +849,6 @@ Lint/Loop:
 
 ################ Things below this are not reviewed/corrected ########
 
-Lint/RequireParentheses:
-  Description: >-
-                 Use parentheses in the method call to avoid confusion
-                 about precedence.
-  Enabled: false
-
-Lint/RescueException:
-  Description: 'Avoid rescuing the Exception class.'
-  Enabled: true
-
 Lint/ShadowingOuterLocalVariable:
   Description: >-
                  Do not use the same name as outer local variable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -847,11 +847,7 @@ Lint/Loop:
                  begin/end/while for post-loop tests.
   Enabled: true
 
-Lint/ParenthesesAsGroupedExpression:
-  Description: >-
-                 Checks for method calls with a space before the opening
-                 parenthesis.
-  Enabled: true
+################ Things below this are not reviewed/corrected ########
 
 Lint/RequireParentheses:
   Description: >-


### PR DESCRIPTION
Clean up lint messages beginning with M all the way through R.
This PR addresses the following cops:
 - Lint/MultipleCompare
 - Lint/NestedMethodDefinition
 - Lint/NestedPercentLiteral
 - Lint/NextWithoutAccumulator
 - Lint/NonLocalExitFromIterator
 - Lint/NumberConversion
 - Lint/OrderedMagicComments
 - Lint/ParenthesesAsGroupedExpression
 - Lint/PercentStringArray
 - Lint/PercentSymbolArray
 - Lint/RandOne
 - Lint/RedundantWithIndex
 - Lint/RedundantWithObject
 - Lint/RegexpAsCondition
 - Lint/RequireParentheses
 - Lint/RescueException
 - Lint/RescueType
 - Lint/ReturnInVoidContext

PTAL