### PR TITLE
Lint Updates: S through Z

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -863,16 +863,6 @@ Lint/RescueException:
   Description: 'Avoid rescuing the Exception class.'
   Enabled: true
 
-Lint/ShadowingOuterLocalVariable:
-  Description: >-
-                 Do not use the same name as outer local variable
-                 for block arguments or block local variables.
-  Enabled: true
-
-Lint/StringConversionInInterpolation:
-  Description: 'Checks for Object#to_s usage in string interpolation.'
-  Enabled: true
-
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -863,10 +863,6 @@ Lint/RescueException:
   Description: 'Avoid rescuing the Exception class.'
   Enabled: true
 
-Lint/Void:
-  Description: 'Possible use of operator/literal/variable in void context.'
-  Enabled: false
-
 Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -863,42 +863,6 @@ Lint/RescueException:
   Description: 'Avoid rescuing the Exception class.'
   Enabled: true
 
-Lint/UnderscorePrefixedVariableName:
-  Description: 'Do not use prefix `_` for a variable that is used.'
-  Enabled: true
-
-Lint/UnusedBlockArgument:
-  Description: 'Checks for unused block arguments.'
-  Enabled: true
-
-Lint/UnusedMethodArgument:
-  Description: 'Checks for unused method arguments.'
-  Enabled: true
-
-Lint/UnreachableCode:
-  Description: 'Unreachable code.'
-  Enabled: true
-
-Lint/UselessAccessModifier:
-  Description: 'Checks for useless access modifiers.'
-  Enabled: true
-
-Lint/UselessAssignment:
-  Description: 'Checks for useless assignment to a local variable.'
-  Enabled: true
-
-Lint/UselessComparison:
-  Description: 'Checks for comparison of something with itself.'
-  Enabled: true
-
-Lint/UselessElseWithoutRescue:
-  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
-  Enabled: true
-
-Lint/UselessSetterCall:
-  Description: 'Checks for useless setter call to a local variable.'
-  Enabled: true
-
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: false


### PR DESCRIPTION
Final PR for the `Lint` section! Cleans up all cops from S through to Z!
Cops adjusted include:
 - Lint/SafeNavigationChain
 - Lint/SaveNavigationConsistency
 - Lint/ScriptPermission
 - Lint/ShadowedArgument
 - Lint/ShadowinOuterLocalVariable
 - Lint/StringConversionInInterpolation
 - Lint/UnderscorePrefixedVariableName
 - Lint/UnifiedInteger
 - Lint/UnneededCopDisableDirective
 - Lint/UnneededCopEnableDirective
 - Lint/UnneededRequireStatement
 - Lint/UnneededSplatExpansion
 - Lint/UnreachableCode
 - Lint/UnusedArgument
 - Lint/UnusedBlockArgument
 - Lint/UnusedMethodArgument
 - Lint/UriEscapeUnescape
 - Lint/UriRegexp
 - Lint/UselessAccessModifier
 - Lint/UselessAssignment
 - Lint/UselessComparison
 - Lint/UselessElseWithoutRescue
 - Lint/UselessSetterCall
 - Lint/Void

That's one section down!!
PTAL